### PR TITLE
Adds build prefix, allowing more flexibility for version numbers.

### DIFF
--- a/VersionReaderTask/VersionReaderTask.ps1
+++ b/VersionReaderTask/VersionReaderTask.ps1
@@ -1,6 +1,7 @@
 ﻿Param (
     [string]$searchPattern = "**\*.??proj",
-	[string]$variablesPrefix
+    [string]$variablesPrefix,
+    [string]$buildPrefix = "."
 )
 
 # Write all params to the console.
@@ -8,12 +9,14 @@ Write-Host "VersionReader v1.5"
 Write-Host "=================="
 Write-Host ("Search Pattern: " + $searchPattern)
 Write-Host ("Variables Prefix: " + $variablesPrefix)
+Write-Host ("Build Prefix: " + $buildPrefix)
 
 function SetBuildVariable([string]$varName, [string]$varValue)
 {
-	Write-Host ("Setting variable " + $variablesPrefix + $varName + " to '" + $varValue + "' and build is " + $Env:BUILD_BUILDID)
-    Write-Output ("##vso[task.setvariable variable=" + $variablesPrefix + $varName + ";]" +  $varValue )
-    Write-Output ("##vso[task.setvariable variable=" + $variablesPrefix + $varName + "_Build;]" +  $varValue + "." + $Env:BUILD_BUILDID )
+    $varName = $variablesPrefix + $varName
+	Write-Host ("Setting variable " + $varName + " to '" + $varValue + "' and build is " + $Env:BUILD_BUILDID)
+    Write-Output ("##vso[task.setvariable variable=" + $varName + ";]" +  $varValue )
+    Write-Output ("##vso[task.setvariable variable=" + $varName + "_Build;]" +  $varValue + $buildPrefix + $Env:BUILD_BUILDID )
 }
 
 function SetVersionVariables([xml]$xml)

--- a/VersionReaderTask/task.json
+++ b/VersionReaderTask/task.json
@@ -28,6 +28,14 @@
         "defaultValue": "",
         "helpMarkDown": "Each variable generated will be prefixed with this value.",
         "required":  false
+    },
+    {
+        "name": "buildPrefix",
+        "type": "string",
+        "label": "Build Prefix",
+        "defaultValue": "",
+        "helpMarkDown": "The build number will be prefixed with this value.",
+        "required":  false
     }
   ],
   "execution": {


### PR DESCRIPTION
Hi,
I love this task, but would like to be able to customise the output a little more.

Essentially this change allows you to specify a string to prefix the build number with. If it is not provided then it will continue to use the `.` character.

This will allow things like `1.2.3-alpha12` and the like. 